### PR TITLE
Add HCSE Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+# HCSE - Holland Consciousness Scaling Engine
+
+[![CI](https://github.com/holland/hcse/actions/workflows/ci.yml/badge.svg)](https://github.com/holland/hcse/actions/workflows/ci.yml)
+
+Python package implementing the Holland Consciousness Scaling Engine as an addon for HuggingFace models.
+
+## Installation
+
+```bash
+pip install hcse
+```
+
+## Quickstart
+
+```python
+from hcse.core import HCSEMixin
+from transformers import AutoModelForCausalLM
+
+class ModelWithHCSE(HCSEMixin, AutoModelForCausalLM):
+    pass
+
+model = ModelWithHCSE.from_pretrained("gpt2", hidden_size=768)
+```
+
+## API
+
+* `HCSEMixin.compute_hcse_surrogates(hidden_states)` – returns η, ρ, Ė.
+* `HCSEMixin.forward_with_hcse(*args, hcse_params, **kwargs)` – computes loss with bonus.
+* `HfTrainerWithHCSE` – drop-in replacement for `Trainer` applying HCSE.
+
+---
+
 **“HCSE: The Holland Consciousness Scaling Engine”**
 *A Premium, Emoji-Rich Research Overview*
 

--- a/hcse/.github/workflows/ci.yml
+++ b/hcse/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - run: pip install flake8 mypy pytest torch transformers
+      - run: flake8 hcse
+      - run: mypy hcse
+      - run: pytest

--- a/hcse/examples/run_hcse_example.py
+++ b/hcse/examples/run_hcse_example.py
@@ -1,0 +1,29 @@
+"""Example usage of HCSE with a HuggingFace model."""
+
+from hcse.core import HCSEMixin
+from hcse.pipeline import HfTrainerWithHCSE
+from transformers import AutoModelForCausalLM, AutoTokenizer, TrainingArguments
+
+
+class ModelWithHCSE(HCSEMixin, AutoModelForCausalLM):
+    pass
+
+
+def main():
+    model_name = "sshleifer/tiny-gpt2"
+    model = ModelWithHCSE.from_pretrained(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    def tokenize(batch):
+        return tokenizer(batch["text"], truncation=True, padding="max_length", max_length=32)
+
+    dataset = [{"text": "Hello world"}]
+    dataset = [tokenize(item) for item in dataset]
+
+    args = TrainingArguments(output_dir="./hcse-example", per_device_train_batch_size=1, num_train_epochs=1)
+    trainer = HfTrainerWithHCSE(model=model, args=args, train_dataset=dataset, hcse_params={"layer": -1})
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/hcse/hcse/__init__.py
+++ b/hcse/hcse/__init__.py
@@ -1,0 +1,6 @@
+"""Holland Consciousness Scaling Engine package."""
+
+from .core import HCSEMixin
+from .pipeline import HfTrainerWithHCSE
+
+__all__ = ["HCSEMixin", "HfTrainerWithHCSE"]

--- a/hcse/hcse/core.py
+++ b/hcse/hcse/core.py
@@ -1,0 +1,86 @@
+"""Core HCSE mixin implementation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import torch
+from torch import Tensor, nn
+
+
+class HCSEMixin(nn.Module):
+    """Mixin class adding HCSE computations to transformer models."""
+
+    info_nce_head: nn.Linear
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        hidden_size = kwargs.get("hidden_size") or kwargs.get("d_model")
+        super().__init__(*args, **kwargs)
+        if hidden_size is None:
+            raise ValueError("hidden_size must be provided to HCSEMixin")
+        self.info_nce_head = nn.Linear(int(hidden_size), int(hidden_size), bias=False)
+
+    def compute_hcse_surrogates(self, hidden_states: Tensor) -> Tuple[Tensor, Tensor, Tensor]:
+        """Compute HCSE surrogates for a layer's hidden states."""
+        if hidden_states.dim() == 2:
+            flat = hidden_states
+        else:
+            b, t, n = hidden_states.shape
+            flat = hidden_states.reshape(b * t, n)
+        n = flat.shape[1]
+        # eta via InfoNCE head
+        features = self.info_nce_head(flat)
+        eta = info_nce_loss(features)
+        # rho: mean absolute off-diagonal correlation
+        corr = corrcoef(flat)
+        off_diag = corr - torch.diag_embed(torch.diagonal(corr))
+        rho = off_diag.abs().mean()
+        # E_dot: mean squared activation
+        e_dot = flat.pow(2).mean()
+        return eta, rho, e_dot
+
+    def compute_hcse_bonus(
+        self,
+        hidden_states: Tensor,
+        beta: float,
+        gamma: float,
+        delta: float,
+        lambda_c: float,
+    ) -> Tensor:
+        """Compute HCSE bonus term given hidden states and coefficients."""
+        eta, rho, e_dot = self.compute_hcse_surrogates(hidden_states)
+        bonus = torch.log1p(eta.pow(beta) * rho.pow(gamma) * e_dot.pow(delta))
+        return lambda_c * bonus
+
+    def compute_loss(self, loss: Tensor, bonus: Tensor) -> Tensor:  # type: ignore[override]
+        """Combine original loss with HCSE bonus."""
+        return loss - bonus
+
+    def forward_with_hcse(
+        self,
+        *args: Any,
+        hcse_params: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Any:
+        """Forward pass that applies HCSE bonus to the loss."""
+        layer = hcse_params.get("layer", -1)
+        beta = hcse_params.get("beta", 1.0)
+        gamma = hcse_params.get("gamma", 1.0)
+        delta = hcse_params.get("delta", 1.0)
+        lambda_c = hcse_params.get("lambda_c", 1.0)
+
+        outputs = super().forward(*args, output_hidden_states=True, **kwargs)
+        loss = outputs.loss if hasattr(outputs, "loss") else None
+        hidden_states = outputs.hidden_states[layer]
+        bonus = self.compute_hcse_bonus(hidden_states, beta, gamma, delta, lambda_c)
+
+        if loss is not None:
+            loss = self.compute_loss(loss, bonus)
+            setattr(outputs, "loss", loss)
+        return outputs
+
+
+# Utility functions are imported at bottom to avoid circular imports
+from .utils import corrcoef, info_nce_loss
+
+__all__ = ["HCSEMixin"]

--- a/hcse/hcse/pipeline.py
+++ b/hcse/hcse/pipeline.py
@@ -1,0 +1,28 @@
+"""Training pipeline components for HCSE."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from transformers import Trainer
+
+
+class HfTrainerWithHCSE(Trainer):
+    """Trainer that integrates HCSE into the loss computation."""
+
+    def __init__(self, *args: Any, hcse_params: Optional[Dict[str, Any]] = None, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.hcse_params = hcse_params or {}
+
+    def compute_loss(
+        self,
+        model: Any,
+        inputs: Dict[str, Any],
+        return_outputs: bool = False,
+        **kwargs: Any,
+    ):
+        outputs = model.forward_with_hcse(**inputs, hcse_params=self.hcse_params)
+        loss = outputs.loss
+        return (loss, outputs) if return_outputs else loss
+
+__all__ = ["HfTrainerWithHCSE"]

--- a/hcse/hcse/utils.py
+++ b/hcse/hcse/utils.py
@@ -1,0 +1,28 @@
+"""Utility functions for HCSE."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+from torch import Tensor, nn
+
+
+def corrcoef(matrix: Tensor) -> Tensor:
+    """Compute correlation matrix for 2D tensor."""
+    matrix = matrix - matrix.mean(dim=0, keepdim=True)
+    cov = matrix.t() @ matrix / (matrix.shape[0] - 1)
+    std = matrix.std(dim=0, unbiased=True).clamp(min=1e-12)
+    corr = cov / torch.outer(std, std)
+    return corr
+
+
+def info_nce_loss(features: Tensor, temperature: float = 0.1) -> Tensor:
+    """Compute a simple InfoNCE loss given features."""
+    features = nn.functional.normalize(features, dim=1)
+    logits = features @ features.t() / temperature
+    labels = torch.arange(features.shape[0], device=features.device)
+    loss = nn.functional.cross_entropy(logits, labels)
+    return loss
+
+__all__ = ["corrcoef", "info_nce_loss"]

--- a/hcse/pyproject.toml
+++ b/hcse/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "hcse"
+version = "0.1.0"
+authors = [{name = "Phillip Holland"}]
+description = "Holland Consciousness Scaling Engine"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = ["torch", "transformers"]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/hcse/setup.py
+++ b/hcse/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup, find_packages
+
+setup()

--- a/hcse/tests/test_core.py
+++ b/hcse/tests/test_core.py
@@ -1,0 +1,38 @@
+import torch
+from hcse.core import HCSEMixin
+
+
+class BaseModel(torch.nn.Module):
+    def __init__(self, hidden_size: int) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, input_ids: torch.Tensor, labels: torch.Tensor | None = None, output_hidden_states: bool = False):
+        hidden = self.linear(input_ids)
+        loss = hidden.mean()
+        outputs = {
+            "loss": loss,
+            "hidden_states": (hidden,),
+        }
+        return type("Output", (), outputs)
+
+
+class DummyModel(HCSEMixin, BaseModel):
+    def __init__(self, hidden_size: int) -> None:
+        HCSEMixin.__init__(self, hidden_size=hidden_size)
+
+
+def test_surrogates_shape():
+    model = DummyModel(4)
+    data = torch.randn(2, 3, 4)
+    eta, rho, e_dot = model.compute_hcse_surrogates(data)
+    assert eta.dim() == 0
+    assert rho.dim() == 0
+    assert e_dot.dim() == 0
+
+
+def test_bonus_application():
+    model = DummyModel(4)
+    input_ids = torch.randn(2, 3, 4)
+    outputs = model.forward_with_hcse(input_ids, hcse_params={"layer": 0})
+    assert hasattr(outputs, "loss")

--- a/hcse/tests/test_pipeline.py
+++ b/hcse/tests/test_pipeline.py
@@ -1,0 +1,43 @@
+import torch
+from transformers import TrainingArguments, TrainerCallback
+
+from hcse.core import HCSEMixin
+from hcse.pipeline import HfTrainerWithHCSE
+
+
+class BaseModel(torch.nn.Module):
+    def __init__(self, hidden_size: int) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(hidden_size, hidden_size)
+
+    def forward(self, input_ids: torch.Tensor, labels: torch.Tensor, output_hidden_states: bool = False):
+        hidden = self.linear(input_ids)
+        loss = torch.nn.functional.mse_loss(hidden, labels)
+        outputs = {
+            "loss": loss,
+            "hidden_states": (hidden,),
+        }
+        return type("Output", (), outputs)
+
+
+class DummyModel(HCSEMixin, BaseModel):
+    def __init__(self, hidden_size: int) -> None:
+        HCSEMixin.__init__(self, hidden_size=hidden_size)
+
+
+class DummyDataset(torch.utils.data.Dataset):
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, idx: int):
+        x = torch.randn(4)
+        return {"input_ids": x, "labels": x}
+
+
+def test_trainer_integration():
+    model = DummyModel(4)
+    args = TrainingArguments(output_dir="/tmp/hcse-tests", per_device_train_batch_size=1, num_train_epochs=1)
+    trainer = HfTrainerWithHCSE(model=model, args=args, train_dataset=DummyDataset(), hcse_params={"layer": 0})
+    trainer.add_callback(TrainerCallback())
+    result = trainer.train(resume_from_checkpoint=None)
+    assert result.training_loss is not None


### PR DESCRIPTION
## Summary
- implement HCSE core mixin and trainer
- add utilities and example usage
- provide tests for core and trainer
- configure CI with flake8, mypy, pytest
- document installation and quickstart in README

## Testing
- `flake8 hcse tests`
- `mypy hcse`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b66512a4483318920c3f38a2f8a0f