### PR TITLE
Add package wrapper for HCSE module

### DIFF
--- a/hcse/__init__.py
+++ b/hcse/__init__.py
@@ -1,0 +1,9 @@
+from importlib import import_module
+
+# Re-export submodule from nested package for backward compatibility
+_submodule = import_module('hcse.hcse')
+
+for attr in getattr(_submodule, '__all__', []):
+    globals()[attr] = getattr(_submodule, attr)
+
+__all__ = getattr(_submodule, '__all__', [])


### PR DESCRIPTION
## Summary
- expose `hcse.core` and pipeline through new top-level `hcse` package
- keep implementation in `hcse/hcse`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6ba307d4833186aef5596140faf2