### PR TITLE
Implement corrcoef and InfoNCE utilities

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,16 @@
+import torch
+from hcse.utils import corrcoef, info_nce_loss
+
+
+def test_corrcoef_basic():
+    x = torch.randn(10, 4)
+    c = corrcoef(x)
+    assert c.shape == (4, 4)
+    assert torch.allclose(torch.diag(c), torch.ones(4), atol=1e-6)
+
+
+def test_info_nce_loss_scalar():
+    feats = torch.randn(6, 8)
+    loss = info_nce_loss(feats)
+    assert loss.dim() == 0
+    assert loss.item() > 0


### PR DESCRIPTION
## Summary
- implement correlation matrix and InfoNCE loss in `hcse/utils.py`
- add unit tests for these helpers in `tests/test_core.py`
- clean up pycache artefacts

## Testing
- `pytest -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686b6eb3d0948331adee11d3c1af8c20