### PR TITLE
Add spectral entropy analysis and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Install in editable mode and run a short simulation:
 ```bash
 pip install -e .
 hdq-cli hdq-sim
+hdq-cli hdq-analyze --steps 10
 ```
 ---
 

--- a/holland_dual/quantum/huqce/__init__.py
+++ b/holland_dual/quantum/huqce/__init__.py
@@ -1,0 +1,11 @@
+from .simulation import HuqceParams, HuqceSimulator
+from .solver import crank_nicolson_step, compute_momentum_expectation
+from .analysis import spectral_entropy
+
+__all__ = [
+    "HuqceParams",
+    "HuqceSimulator",
+    "crank_nicolson_step",
+    "compute_momentum_expectation",
+    "spectral_entropy",
+]

--- a/holland_dual/quantum/huqce/analysis.py
+++ b/holland_dual/quantum/huqce/analysis.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from huqce.analysis import spectral_entropy
+
+__all__ = ["spectral_entropy"]

--- a/holland_dual/shared/cli.py
+++ b/holland_dual/shared/cli.py
@@ -7,6 +7,7 @@ from typing import Optional
 import typer
 
 from holland_dual.quantum.huqce.simulation import HuqceParams, HuqceSimulator
+from holland_dual.quantum.huqce.analysis import spectral_entropy
 from holland_dual.fusion.adapter import simulation_to_activation
 
 app = typer.Typer(help="Holland Dual CLI")
@@ -31,6 +32,16 @@ def hdf_fuse() -> None:
     print(acts.shape)
 
 
+@app.command()
+def hdq_analyze(steps: int = 50) -> None:
+    """Run simulation and print spectral entropy."""
+    params = HuqceParams(steps=steps)
+    sim = HuqceSimulator(params)
+    psi = sim.run()
+    ent = spectral_entropy(psi)
+    print(f"spectral entropy: {ent:.4f}")
+
+
 cli = app
 
-__all__ = ["cli"]
+__all__ = ["cli", "hdq_sim", "hdf_fuse", "hdq_analyze"]

--- a/holland_dual/tests/test_cli.py
+++ b/holland_dual/tests/test_cli.py
@@ -1,0 +1,10 @@
+from typer.testing import CliRunner
+
+from holland_dual.shared.cli import app
+
+
+def test_hdq_analyze():
+    runner = CliRunner()
+    result = runner.invoke(app, ["hdq-analyze", "--steps", "5"])
+    assert result.exit_code == 0
+    assert "spectral entropy" in result.stdout

--- a/huqce/__init__.py
+++ b/huqce/__init__.py
@@ -1,0 +1,11 @@
+from .simulation import HuqceParams, HuqceSimulator
+from .solver import crank_nicolson_step, compute_momentum_expectation
+from .analysis import spectral_entropy
+
+__all__ = [
+    "HuqceParams",
+    "HuqceSimulator",
+    "crank_nicolson_step",
+    "compute_momentum_expectation",
+    "spectral_entropy",
+]

--- a/huqce/analysis.py
+++ b/huqce/analysis.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def spectral_entropy(signal: ArrayLike) -> float:
+    """Compute spectral entropy of a real or complex 1D signal.
+
+    Parameters
+    ----------
+    signal : ArrayLike
+        Input array representing the wavefunction or time series.
+
+    Returns
+    -------
+    float
+        Shannon entropy of the normalized power spectrum.
+    """
+    arr = np.asarray(signal)
+    spectrum = np.fft.fft(arr)
+    power = np.abs(spectrum) ** 2
+    if power.sum() == 0:
+        return 0.0
+    prob = power / power.sum()
+    entropy = -np.sum(prob * np.log(prob + 1e-12))
+    return float(entropy)
+
+
+__all__ = ["spectral_entropy"]

--- a/huqce/tests/test_analysis.py
+++ b/huqce/tests/test_analysis.py
@@ -1,0 +1,15 @@
+import numpy as np
+from huqce.analysis import spectral_entropy
+
+
+def test_spectral_entropy_constant():
+    const_signal = np.ones(8)
+    ent = spectral_entropy(const_signal)
+    assert ent < 1e-6
+
+
+def test_spectral_entropy_random():
+    np.random.seed(0)
+    sig = np.random.randn(128)
+    ent = spectral_entropy(sig)
+    assert ent > 0


### PR DESCRIPTION
## Summary
- export new spectral entropy metric in `huqce`
- expose analysis command via CLI
- update README usage example
- add unit tests for spectral entropy and CLI command

## Testing
- `pytest huqce/tests/test_analysis.py -q` *(fails: ModuleNotFoundError: numpy)*

------
https://chatgpt.com/codex/tasks/task_e_687ba720c0448331ad84aed83e5b8840