### PR TITLE
Install hcse and huqce packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,4 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["holland_dual*", "hcse*", "huqce*"]
-exclude = ["hcse*", "huqce*"]
+exclude = []


### PR DESCRIPTION
## Summary
- include `hcse` and `huqce` in the package build

## Testing
- `pip install -e . --no-deps`
- `PYTHONPATH=stubs:$PYTHONPATH python -c "import hcse, huqce; print('import success')"`

------
https://chatgpt.com/codex/tasks/task_e_687bb6564c608331a7588cb11b067c15