### PR TITLE
Add huqce pyproject and fix tests

### DIFF
--- a/huqce/pyproject.toml
+++ b/huqce/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "huqce"
+version = "0.1.0"
+authors = [{name = "Phillip Holland"}]
+description = "Holland Universal Quantum Computing Engine"
+requires-python = ">=3.8"
+dependencies = ["numpy"]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["huqce"]
+package-dir = {"huqce" = "."}

--- a/huqce/tests/test_simulation.py
+++ b/huqce/tests/test_simulation.py
@@ -1,4 +1,3 @@
-import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 import numpy as np
 from huqce.simulation import HuqceParams, HuqceSimulator
 


### PR DESCRIPTION
## Summary
- add a standalone `pyproject.toml` for the `huqce` package
- clean up test to rely on installed package

## Testing
- `pip install -e huqce`
- `pytest huqce/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb7d8bbbc83319081734439d0476a