### PR TITLE
Add accelerate as optional dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,15 @@ psi = HuqceSimulator(params).run()
 ```
 
 This addition demonstrates how chaotic dynamics can be integrated alongside HCSE's cognitive metrics.
+
+## Testing
+
+The test suite requires the optional [accelerate](https://github.com/huggingface/accelerate) package.
+Install the development dependencies and run `pytest`:
+
+```bash
+pip install -e .[accelerate]
+pytest
+```
+
+`accelerate` is optional for using the library itself but needed for running tests.

--- a/hcse/.github/workflows/ci.yml
+++ b/hcse/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install flake8 mypy pytest torch transformers
+      - run: pip install flake8 mypy pytest torch transformers accelerate>=0.26.0
       - run: flake8 hcse
       - run: mypy hcse
       - run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "transformers",
 ]
 
+[project.optional-dependencies]
+accelerate = ["accelerate>=0.26.0"]
+
 [project.scripts]
 hdq-cli = "holland_dual.shared.cli:cli"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+flake8
+mypy
+pytest
+torch
+transformers
+accelerate>=0.26.0


### PR DESCRIPTION
## Summary
- list accelerate in project optional dependencies
- create `requirements-dev.txt` including accelerate
- mention accelerate requirement for running tests in README
- install accelerate in CI workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687bb91d1590833187f4cce4220b68db