### PR TITLE
Add HCSE overview SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository now provides a unified package `holland_dual` combining the exis
 HCSE cognition tools with HUQCE quantum simulations. A CLI entrypoint `hdq-cli` exposes
 basic commands to run simulations and demonstrate the fusion adapter.
 
+![HCSE Overview](docs/hcse_overview.svg)
+
 [![CI](https://github.com/holland/hcse/actions/workflows/ci.yml/badge.svg)](https://github.com/holland/hcse/actions/workflows/ci.yml)
 
 Python package implementing the Holland Consciousness Scaling Engine as an addon for HuggingFace models.

--- a/docs/hcse_overview.svg
+++ b/docs/hcse_overview.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="640" height="300" viewBox="0 0 640 300" xmlns="http://www.w3.org/2000/svg" font-family="Arial, Helvetica, sans-serif">
+  <rect x="40" y="80" width="160" height="80" rx="10" fill="#e0f7fa" stroke="#006064" stroke-width="2"/>
+  <text x="120" y="125" font-size="20" text-anchor="middle" fill="#006064">HCSE</text>
+  <rect x="440" y="80" width="160" height="80" rx="10" fill="#fce4ec" stroke="#880e4f" stroke-width="2"/>
+  <text x="520" y="125" font-size="20" text-anchor="middle" fill="#880e4f">HUQCE</text>
+  <ellipse cx="320" cy="150" rx="90" ry="40" fill="#fff3e0" stroke="#e65100" stroke-width="2"/>
+  <text x="320" y="155" font-size="16" text-anchor="middle" fill="#e65100">Fusion Adapter</text>
+  <line x1="200" y1="120" x2="230" y2="150" stroke="#006064" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="440" y1="120" x2="410" y2="150" stroke="#880e4f" stroke-width="2" marker-end="url(#arrow)"/>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="black" />
+    </marker>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- create simple HCSE & HUQCE interaction diagram in `docs/hcse_overview.svg`
- embed the new diagram in the README

## Testing
- `pip install -e .[accelerate]` *(fails: large downloads)*
- `pytest -q` *(fails: ModuleNotFoundError: torch, numpy, typer)*

------
https://chatgpt.com/codex/tasks/task_e_687bca6147348331afac96d226cd3486