### PR TITLE
Fix complex casting

### DIFF
--- a/holland_dual/quantum/huqce/solver.py
+++ b/holland_dual/quantum/huqce/solver.py
@@ -63,7 +63,8 @@ def crank_nicolson_step(
 
 def compute_momentum_expectation(psi: ArrayLike, dx: float) -> float:
     grad = np.gradient(psi, dx)
-    return float(np.sum(np.conj(psi) * (-1j * grad)) * dx)
+    expectation = np.sum(np.conj(psi) * (-1j * grad)) * dx
+    return float(np.real(expectation))
 
 
 __all__ = ["crank_nicolson_step", "compute_momentum_expectation"]

--- a/holland_dual/tests/test_cli.py
+++ b/holland_dual/tests/test_cli.py
@@ -1,10 +1,15 @@
 from typer.testing import CliRunner
+import numpy as np
+import warnings
+from numpy.exceptions import ComplexWarning
 
 from holland_dual.shared.cli import app
 
 
 def test_hdq_analyze():
     runner = CliRunner()
-    result = runner.invoke(app, ["hdq-analyze", "--steps", "5"])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=ComplexWarning)
+        result = runner.invoke(app, ["hdq-analyze", "--steps", "5"])
     assert result.exit_code == 0
     assert "spectral entropy" in result.stdout

--- a/holland_dual/tests/test_fusion.py
+++ b/holland_dual/tests/test_fusion.py
@@ -1,7 +1,12 @@
 from holland_dual.fusion.adapter import simulation_to_activation
 from holland_dual.quantum.huqce.simulation import HuqceParams
+import numpy as np
+import warnings
+from numpy.exceptions import ComplexWarning
 
 
 def test_adapter_shape():
-    acts = simulation_to_activation(HuqceParams(steps=1))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=ComplexWarning)
+        acts = simulation_to_activation(HuqceParams(steps=1))
     assert acts.dim() == 2

--- a/huqce/solver.py
+++ b/huqce/solver.py
@@ -63,7 +63,8 @@ def crank_nicolson_step(
 
 def compute_momentum_expectation(psi: ArrayLike, dx: float) -> float:
     grad = np.gradient(psi, dx)
-    return float(np.sum(np.conj(psi) * (-1j * grad)) * dx)
+    expectation = np.sum(np.conj(psi) * (-1j * grad)) * dx
+    return float(np.real(expectation))
 
 
 __all__ = ["crank_nicolson_step", "compute_momentum_expectation"]

--- a/huqce/tests/test_simulation.py
+++ b/huqce/tests/test_simulation.py
@@ -1,9 +1,13 @@
 import numpy as np
+import warnings
+from numpy.exceptions import ComplexWarning
 from huqce.simulation import HuqceParams, HuqceSimulator
 
 
 def test_norm_conservation():
-    params = HuqceParams(steps=10)
-    psi = HuqceSimulator(params).run()
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=ComplexWarning)
+        params = HuqceParams(steps=10)
+        psi = HuqceSimulator(params).run()
     final_norm = np.linalg.norm(psi)
     assert abs(final_norm - 1.0) < 1e-5


### PR DESCRIPTION
## Summary
- avoid casting complex to float in momentum expectation calculation
- verify ComplexWarnings are treated as test failures

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bd51084808331b95fa252d042a6b4