### PR TITLE
Fix solver casting and update tests

### DIFF
--- a/holland_dual/quantum/huqce/solver.py
+++ b/holland_dual/quantum/huqce/solver.py
@@ -61,10 +61,10 @@ def crank_nicolson_step(
     return psi_next
 
 
-def compute_momentum_expectation(psi: ArrayLike, dx: float) -> float:
+def compute_momentum_expectation(psi: ArrayLike, dx: float) -> complex:
     grad = np.gradient(psi, dx)
     expectation = np.sum(np.conj(psi) * (-1j * grad)) * dx
-    return float(np.real(expectation))
+    return expectation
 
 
 __all__ = ["crank_nicolson_step", "compute_momentum_expectation"]

--- a/huqce/solver.py
+++ b/huqce/solver.py
@@ -61,10 +61,10 @@ def crank_nicolson_step(
     return psi_next
 
 
-def compute_momentum_expectation(psi: ArrayLike, dx: float) -> float:
+def compute_momentum_expectation(psi: ArrayLike, dx: float) -> complex:
     grad = np.gradient(psi, dx)
     expectation = np.sum(np.conj(psi) * (-1j * grad)) * dx
-    return float(np.real(expectation))
+    return expectation
 
 
 __all__ = ["crank_nicolson_step", "compute_momentum_expectation"]

--- a/huqce/tests/test_simulation.py
+++ b/huqce/tests/test_simulation.py
@@ -2,6 +2,7 @@ import numpy as np
 import warnings
 from numpy.exceptions import ComplexWarning
 from huqce.simulation import HuqceParams, HuqceSimulator
+from huqce.solver import compute_momentum_expectation
 
 
 def test_norm_conservation():
@@ -11,3 +12,11 @@ def test_norm_conservation():
         psi = HuqceSimulator(params).run()
     final_norm = np.linalg.norm(psi)
     assert abs(final_norm - 1.0) < 1e-5
+
+
+def test_momentum_expectation_type():
+    psi = np.array([1 + 1j, 0j])
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=ComplexWarning)
+        val = compute_momentum_expectation(psi, 1.0)
+    assert np.iscomplexobj(val)


### PR DESCRIPTION
## Summary
- return complex values from HUQCE momentum expectation helpers
- add a unit test covering complex return type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bdb450d8c8331abf958fa6fb3658b